### PR TITLE
Use `@vercel` Builder packages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,14 +3,14 @@
    "builds": [
       {
          "src": "package.json",
-         "use": "@now/static-build",
+         "use": "@vercel/static-build",
          "config": {
             "distDir": "web/dist"
          }
       },
       {
          "src": "api/src/index.ts",
-         "use": "@now/node-server"
+         "use": "@vercel/node"
       }
    ],
    "routes": [


### PR DESCRIPTION
I noticed that this repository was still using the old `@now` scoped Builder packages for deploying to Vercel. Updating to use the `@vercel` scope ones will remove the warnings in the build logs and ensure you are receiving the latest updates.